### PR TITLE
fix-flaky-mount

### DIFF
--- a/monitor/infra/cloud-init.yml
+++ b/monitor/infra/cloud-init.yml
@@ -2,7 +2,8 @@
 runcmd:
   - echo 'Mounting volume...'
   - mkdir /mnt/prometheus
-  - mount /dev/sdb /mnt/prometheus
+  # Workaround: Volumes are not always detected in the same order
+  - mount /dev/sda /mnt/prometheus || mount /dev/sdb /mnt/prometheus
   - chmod 777 /mnt/prometheus
 
   - echo 'Installing docker...'


### PR DESCRIPTION
why: volumes are not always detected in the same order
If the OS volume is sda, then the mount will fail and will we will
try with sdb (and vice-versa)
Quickly, I didn't found a not ugly command to find not
mounted volumes
