### PR TITLE
WP-1818-trigger-alerts

### DIFF
--- a/monitor/README.md
+++ b/monitor/README.md
@@ -50,3 +50,15 @@ terraform init
 terraform plan -var-file=<file>
 terraform apply -var-file=<file>
 ```
+
+## Alerting Rules
+
+To debug, write or test alerting rules, use `promtool`:
+
+```shell
+docker exec prometheus sh -c "promtool test rules /etc/prometheus/tests.yml"
+```
+
+- Use `--run <test-name>` to execute specific test
+- Use `--debug` to enable debugging and see how many time the alert was
+  in "pending" or "firing" state

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -15,6 +15,9 @@
   ./prometheus-config-generator/generate.py --wazo-host <wazo-ip> -o prometheus-config/prometheus.yml
   ```
 
+- (Optional) Update Alertmanager configuration file:
+  `alertmanager-config/alertmanager.yml`
+
 ## Run Environment
 
 - Start containers: `docker compose up -d`

--- a/monitor/alertmanager-config/alertmanager.yml
+++ b/monitor/alertmanager-config/alertmanager.yml
@@ -1,0 +1,5 @@
+receivers:
+- name: noop
+
+route:
+  receiver: noop

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -35,6 +35,22 @@ services:
       timeout: 1s
       retries: 5
 
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: alertmanager
+    restart: unless-stopped
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./alertmanager-config:/etc/alertmanager:ro
+      - alertmanager-data:/alertmanager:rw
+    healthcheck:
+      test: ["CMD", "wget", "-o", "/dev/null" , "-O", "/dev/null", "http://localhost:9093/-/healthy"]
+      interval: 2s
+      timeout: 1s
+      retries: 5
+
 volumes:
   prometheus-data:
   grafana-data:
+  alertmanager-data:

--- a/monitor/prometheus-config-generator/prometheus.yaml.jinja2
+++ b/monitor/prometheus-config-generator/prometheus.yaml.jinja2
@@ -4,6 +4,11 @@
 global:
   scrape_interval: 15s
 
+alerting:
+  alertmanagers:
+    - static_configs:
+      - targets: ['alertmanager:9093']
+
 scrape_configs:
   - job_name: 'asterisk'
     metrics_path: /api/asterisk/metrics

--- a/monitor/prometheus-config-generator/prometheus.yaml.jinja2
+++ b/monitor/prometheus-config-generator/prometheus.yaml.jinja2
@@ -4,6 +4,9 @@
 global:
   scrape_interval: 15s
 
+rule_files:
+  - /etc/prometheus/alerts.yml
+
 alerting:
   alertmanagers:
     - static_configs:

--- a/monitor/prometheus-config/alerts.yml
+++ b/monitor/prometheus-config/alerts.yml
@@ -2,18 +2,18 @@
 # - ${value}: result from the last evaluation of the "for"
 
 groups:
-- name: Alerting Rules
+- name: Static Rules
   rules:
-  - alert: MemoryRabbitMQ
+  - alert: MemoryLeak
     expr:  |
-      avg_over_time(process_resident_memory_bytes{job="rabbitmq"}[10m])
-      > (avg_over_time(process_resident_memory_bytes{job="rabbitmq"}[50m] offset 10m))
+      avg_over_time(process_resident_memory_bytes[10m])
+      > (avg_over_time(process_resident_memory_bytes[50m] offset 10m))
     for: 30m
     labels:
       severity: warning
     annotations:
-      summary: "{{ $labels.job }} memory increase abnormally: {{ $value }}"
-      description: "{{ $labels.instance }} of job {{ $labels.job }} has a potential memory leak"
+      summary: "Service {{ $labels.job }} has a potential memory leak"
+      description: "Instance **{{ $labels.instance }}**, Memory: {{ $value }}"
 
   - alert: CriticalRAMUsage
     expr: |
@@ -27,5 +27,45 @@ groups:
     labels:
       severity: critical
     annotations:
-      summary: Memory usage has been above 90% for more than 10 minutes
-      description: Instance **{{ $labels.instance }}**
+      summary: "Memory usage has been above 90% for more than 10 minutes"
+      description: "Instance **{{ $labels.instance }}**"
+
+  - alert: CriticalCPULoad
+    expr: |
+      (1 - avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[10m])))
+      * 100 > 96
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: "CPU load average has been above 96% for more than 10 minutes"
+      description: "Instance **{{ $labels.instance }}**"
+
+  - alert: AsteriskTotalCalls
+    # Allow 10m without call
+    expr: increase(asterisk_calls_sum[10m]) == 0.0
+    labels:
+      severity: warning
+    annotations:
+      summary: "Total calls are not increasing"
+      description: "Instance **{{ $labels.instance }}**"
+
+  - alert: PGConnectionUsage
+    expr: sum(pg_stat_activity_count) by (instance) / sum(pg_settings_max_connections) by (instance) * 100 > 90
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: "PostgreSQL connections usage has been above 90% for more than 10 minutes"
+      description: "Instance **{{ $labels.instance }}**"
+
+- name: Scenario Rules
+  rules:
+  - alert: AsteriskSimultCalls
+    expr: asterisk_calls_count > 35
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Simultaneous calls are higher than expected"
+      description: "Instance **{{ $labels.instance }}**, Calls: {{ $value }} > 35"

--- a/monitor/prometheus-config/alerts.yml
+++ b/monitor/prometheus-config/alerts.yml
@@ -4,6 +4,17 @@
 groups:
 - name: Static Rules
   rules:
+  - alert: MemoryLeak
+    expr:  |
+      avg_over_time(namedprocess_namegroup_memory_bytes{memtype="resident"}[10m])
+      > (avg_over_time(namedprocess_namegroup_memory_bytes{memtype="resident"}[50m] offset 10m))
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Service {{ $labels.groupname }} has a potential memory leak"
+      description: "Instance **{{ $labels.instance }}**, Memory: {{ $value }}"
+
   - alert: MemoryLeakFromExporter
     expr:  |
       avg_over_time(process_resident_memory_bytes[10m])

--- a/monitor/prometheus-config/alerts.yml
+++ b/monitor/prometheus-config/alerts.yml
@@ -4,7 +4,7 @@
 groups:
 - name: Static Rules
   rules:
-  - alert: MemoryLeak
+  - alert: MemoryLeakFromExporter
     expr:  |
       avg_over_time(process_resident_memory_bytes[10m])
       > (avg_over_time(process_resident_memory_bytes[50m] offset 10m))
@@ -12,7 +12,7 @@ groups:
     labels:
       severity: warning
     annotations:
-      summary: "Service {{ $labels.job }} has a potential memory leak"
+      summary: "Exporter {{ $labels.job }} has a potential memory leak"
       description: "Instance **{{ $labels.instance }}**, Memory: {{ $value }}"
 
   - alert: CriticalRAMUsage

--- a/monitor/prometheus-config/alerts.yml
+++ b/monitor/prometheus-config/alerts.yml
@@ -14,3 +14,18 @@ groups:
     annotations:
       summary: "{{ $labels.job }} memory increase abnormally: {{ $value }}"
       description: "{{ $labels.instance }} of job {{ $labels.job }} has a potential memory leak"
+
+  - alert: CriticalRAMUsage
+    expr: |
+      (1 -
+        (
+          (node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes)
+          / node_memory_MemTotal_bytes
+        )
+      ) * 100 > 90
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: Memory usage has been above 90% for more than 10 minutes
+      description: Instance **{{ $labels.instance }}**

--- a/monitor/prometheus-config/alerts.yml
+++ b/monitor/prometheus-config/alerts.yml
@@ -1,0 +1,16 @@
+# NOTE:
+# - ${value}: result from the last evaluation of the "for"
+
+groups:
+- name: Alerting Rules
+  rules:
+  - alert: MemoryRabbitMQ
+    expr:  |
+      avg_over_time(process_resident_memory_bytes{job="rabbitmq"}[10m])
+      > (avg_over_time(process_resident_memory_bytes{job="rabbitmq"}[50m] offset 10m))
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      summary: "{{ $labels.job }} memory increase abnormally: {{ $value }}"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} has a potential memory leak"

--- a/monitor/prometheus-config/alerts.yml
+++ b/monitor/prometheus-config/alerts.yml
@@ -70,6 +70,15 @@ groups:
       summary: "PostgreSQL connections usage has been above 90% for more than 10 minutes"
       description: "Instance **{{ $labels.instance }}**"
 
+  - alert: AsteriskFileDescriptors
+    expr: namedprocess_namegroup_open_filedesc{groupname="asterisk"} > (8192 * 0.90)
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Asterisk file descriptors count has been above 90% for more than 5 minutes"
+      description: "Instance **{{ $labels.instance }}**, File Descriptors: {{ $value }}"
+
 - name: Scenario Rules
   rules:
   - alert: AsteriskSimultCalls

--- a/monitor/prometheus-config/tests.yml
+++ b/monitor/prometheus-config/tests.yml
@@ -218,3 +218,20 @@ tests:
             exp_annotations:
               summary: 'PostgreSQL connections usage has been above 90% for more than 10 minutes'
               description: 'Instance **localhost**'
+
+  - name: asterisk file descriptors
+    interval: 1m
+    input_series:
+      - series: 'namedprocess_namegroup_open_filedesc{groupname="asterisk", instance="localhost"}'
+        values: '8000+0x4'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: AsteriskFileDescriptors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: localhost
+              groupname: asterisk
+            exp_annotations:
+              summary: "Asterisk file descriptors count has been above 90% for more than 5 minutes"
+              description: "Instance **localhost**, File Descriptors: 8000"

--- a/monitor/prometheus-config/tests.yml
+++ b/monitor/prometheus-config/tests.yml
@@ -75,48 +75,48 @@ tests:
         alertname: CriticalCPULoad
         exp_alerts: []
 
-  - name: when memory increase by step
+  - name: when exporter memory increase by step
     interval: 1m
     input_series:
       - series: 'process_resident_memory_bytes{job="rabbitmq", instance="localhost"}'
         values: '0 100+0x28 200+0x30'
     alert_rule_test:
       - eval_time: 60m
-        alertname: MemoryLeak
+        alertname: MemoryLeakFromExporter
         exp_alerts:
           - exp_labels:
               severity: warning
               instance: localhost
               job: rabbitmq
             exp_annotations:
-              summary: "Service rabbitmq has a potential memory leak"
+              summary: "Exporter rabbitmq has a potential memory leak"
               description: "Instance **localhost**, Memory: 200"
 
-  - name: when memory decrease by step
+  - name: when exporter memory decrease by step
     interval: 1m
     input_series:
       - series: 'process_resident_memory_bytes{job="rabbitmq", instance="localhost"}'
         values: '0 200+0x28 100+0x30'
     alert_rule_test:
       - eval_time: 60m
-        alertname: MemoryLeak
+        alertname: MemoryLeakFromExporter
         exp_alerts: []
 
-  - name: when memory increase slowly
+  - name: when exporter memory increase slowly
     interval: 1m
     input_series:
       - series: 'process_resident_memory_bytes{job="rabbitmq", instance="localhost"}'
         values: '0 100+1x59'
     alert_rule_test:
       - eval_time: 60m
-        alertname: MemoryLeak
+        alertname: MemoryLeakFromExporter
         exp_alerts:
           - exp_labels:
               severity: warning
               instance: localhost
               job: rabbitmq
             exp_annotations:
-              summary: "Service rabbitmq has a potential memory leak"
+              summary: "Exporter rabbitmq has a potential memory leak"
               description: "Instance **localhost**, Memory: 154.5"
 
   - name: simultaneous calls

--- a/monitor/prometheus-config/tests.yml
+++ b/monitor/prometheus-config/tests.yml
@@ -1,0 +1,56 @@
+rule_files:
+    - alerts.yml
+
+evaluation_interval: 1m
+
+# NOTE:
+# - Avoid to use ambiguous short syntax (1x10) for values
+#   ex: 1x10 will produce 11 values
+# - <metric>[10m] is left-open, i.e. samples with timestamps coinciding with
+#   the left boundary of the range are excluded. That's why dummy series must
+#   have interval less than 10m
+
+tests:
+  - name: when memory increase by step
+    interval: 1m
+    input_series:
+      - series: 'process_resident_memory_bytes{job="rabbitmq", instance="localhost"}'
+        values: '0 100+0x28 200+0x30'
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: MemoryRabbitMQ
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: localhost
+              job: rabbitmq
+            exp_annotations:
+              summary: "rabbitmq memory increase abnormally: 200"
+              description: "localhost of job rabbitmq has a potential memory leak"
+
+  - name: when memory decrease by step
+    interval: 1m
+    input_series:
+      - series: 'process_resident_memory_bytes{job="rabbitmq", instance="localhost"}'
+        values: '0 200+0x28 100+0x30'
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: MemoryRabbitMQ
+        exp_alerts: []
+
+  - name: when memory increase slowly
+    interval: 1m
+    input_series:
+      - series: 'process_resident_memory_bytes{job="rabbitmq", instance="localhost"}'
+        values: '0 100+1x59'
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: MemoryRabbitMQ
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: localhost
+              job: rabbitmq
+            exp_annotations:
+              summary: "rabbitmq memory increase abnormally: 154.5"
+              description: "localhost of job rabbitmq has a potential memory leak"

--- a/monitor/prometheus-config/tests.yml
+++ b/monitor/prometheus-config/tests.yml
@@ -11,7 +11,7 @@ evaluation_interval: 1m
 #   have interval less than 10m
 
 tests:
-  - name: when memory reaches threshold more than 10m
+  - name: when memory firing more than 10m
     interval: 1m
     input_series:
       - series: 'node_memory_MemFree_bytes{instance="localhost"}'
@@ -30,10 +30,10 @@ tests:
               severity: critical
               instance: localhost
             exp_annotations:
-              summary: "Memory usage has been above 90% for more than 10 minutes"
-              description: "Instance **localhost**"
+              summary: 'Memory usage has been above 90% for more than 10 minutes'
+              description: 'Instance **localhost**'
 
-  - name: when memory reaches threshold less than 10m
+  - name: when memory firing less than 10m
     interval: 1m
     input_series:
       - series: 'node_memory_MemFree_bytes{instance="localhost"}'
@@ -49,6 +49,32 @@ tests:
         alertname: CriticalRAMUsage
         exp_alerts: []
 
+  - name: when cpu load average firing more than 10m
+    interval: 1m
+    input_series:
+      - series: 'node_cpu_seconds_total{instance="localhost", mode="idle"}'
+        values: '0+2x20'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CriticalCPULoad
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: localhost
+            exp_annotations:
+              summary: "CPU load average has been above 96% for more than 10 minutes"
+              description: 'Instance **localhost**'
+
+  - name: when cpu load average firing less than 10m
+    interval: 1m
+    input_series:
+      - series: 'node_cpu_seconds_total{instance="localhost", mode="idle"}'
+        values: '0+4x20'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CriticalCPULoad
+        exp_alerts: []
+
   - name: when memory increase by step
     interval: 1m
     input_series:
@@ -56,15 +82,15 @@ tests:
         values: '0 100+0x28 200+0x30'
     alert_rule_test:
       - eval_time: 60m
-        alertname: MemoryRabbitMQ
+        alertname: MemoryLeak
         exp_alerts:
           - exp_labels:
               severity: warning
               instance: localhost
               job: rabbitmq
             exp_annotations:
-              summary: "rabbitmq memory increase abnormally: 200"
-              description: "localhost of job rabbitmq has a potential memory leak"
+              summary: "Service rabbitmq has a potential memory leak"
+              description: "Instance **localhost**, Memory: 200"
 
   - name: when memory decrease by step
     interval: 1m
@@ -73,7 +99,7 @@ tests:
         values: '0 200+0x28 100+0x30'
     alert_rule_test:
       - eval_time: 60m
-        alertname: MemoryRabbitMQ
+        alertname: MemoryLeak
         exp_alerts: []
 
   - name: when memory increase slowly
@@ -83,12 +109,81 @@ tests:
         values: '0 100+1x59'
     alert_rule_test:
       - eval_time: 60m
-        alertname: MemoryRabbitMQ
+        alertname: MemoryLeak
         exp_alerts:
           - exp_labels:
               severity: warning
               instance: localhost
               job: rabbitmq
             exp_annotations:
-              summary: "rabbitmq memory increase abnormally: 154.5"
-              description: "localhost of job rabbitmq has a potential memory leak"
+              summary: "Service rabbitmq has a potential memory leak"
+              description: "Instance **localhost**, Memory: 154.5"
+
+  - name: simultaneous calls
+    interval: 1m
+    input_series:
+      - series: 'asterisk_calls_count{instance="localhost"}'
+        values: '0+0x9 42+0x9'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: AsteriskSimultCalls
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: AsteriskSimultCalls
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: localhost
+            exp_annotations:
+              summary: 'Simultaneous calls are higher than expected'
+              description: 'Instance **localhost**, Calls: 42 > 35'
+
+  - name: total calls
+    interval: 1m
+    input_series:
+      - series: 'asterisk_calls_sum{instance="localhost"}'
+        values: '0+1x10 10+0x9'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: AsteriskTotalCalls
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: AsteriskTotalCalls
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: localhost
+            exp_annotations:
+              summary: 'Total calls are not increasing'
+              description: 'Instance **localhost**'
+
+  - name: total calls when reset
+    interval: 1m
+    input_series:
+      - series: 'asterisk_calls_sum{instance="localhost"}'
+        values: '0+1x10 0 0 0+1x7'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: AsteriskTotalCalls
+        exp_alerts: []
+
+  - name: postgres connections
+    interval: 1m
+    input_series:
+      - series: 'pg_stat_activity_count{instance="localhost"}'
+        values: '50+0x9 91+0x10'
+      - series: 'pg_settings_max_connections{instance="localhost"}'
+        values: '100+0x19'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PGConnectionUsage
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: PGConnectionUsage
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: localhost
+            exp_annotations:
+              summary: 'PostgreSQL connections usage has been above 90% for more than 10 minutes'
+              description: 'Instance **localhost**'

--- a/monitor/prometheus-config/tests.yml
+++ b/monitor/prometheus-config/tests.yml
@@ -11,6 +11,44 @@ evaluation_interval: 1m
 #   have interval less than 10m
 
 tests:
+  - name: when memory reaches threshold more than 10m
+    interval: 1m
+    input_series:
+      - series: 'node_memory_MemFree_bytes{instance="localhost"}'
+        values: '2+0x10'
+      - series: 'node_memory_Buffers_bytes{instance="localhost"}'
+        values: '2+0x10'
+      - series: 'node_memory_Cached_bytes{instance="localhost"}'
+        values: '2+0x10'
+      - series: 'node_memory_MemTotal_bytes{instance="localhost"}'
+        values: '100+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: CriticalRAMUsage
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: localhost
+            exp_annotations:
+              summary: "Memory usage has been above 90% for more than 10 minutes"
+              description: "Instance **localhost**"
+
+  - name: when memory reaches threshold less than 10m
+    interval: 1m
+    input_series:
+      - series: 'node_memory_MemFree_bytes{instance="localhost"}'
+        values: '30+0x8 2 2'
+      - series: 'node_memory_Buffers_bytes{instance="localhost"}'
+        values: '30+0x8 2 2'
+      - series: 'node_memory_Cached_bytes{instance="localhost"}'
+        values: '30+0x8 2 2'
+      - series: 'node_memory_MemTotal_bytes{instance="localhost"}'
+        values: '100+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: CriticalRAMUsage
+        exp_alerts: []
+
   - name: when memory increase by step
     interval: 1m
     input_series:

--- a/monitor/prometheus-config/tests.yml
+++ b/monitor/prometheus-config/tests.yml
@@ -75,10 +75,12 @@ tests:
         alertname: CriticalCPULoad
         exp_alerts: []
 
-  - name: when exporter memory increase by step
+  - name: when memory increase by step
     interval: 1m
     input_series:
       - series: 'process_resident_memory_bytes{job="rabbitmq", instance="localhost"}'
+        values: '0 100+0x28 200+0x30'
+      - series: 'namedprocess_namegroup_memory_bytes{groupname="rabbitmq", memtype="resident",instance="localhost"}'
         values: '0 100+0x28 200+0x30'
     alert_rule_test:
       - eval_time: 60m
@@ -91,21 +93,39 @@ tests:
             exp_annotations:
               summary: "Exporter rabbitmq has a potential memory leak"
               description: "Instance **localhost**, Memory: 200"
+      - eval_time: 60m
+        alertname: MemoryLeak
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: localhost
+              groupname: rabbitmq
+              memtype: resident
+            exp_annotations:
+              summary: "Service rabbitmq has a potential memory leak"
+              description: "Instance **localhost**, Memory: 200"
 
-  - name: when exporter memory decrease by step
+  - name: when memory decrease by step
     interval: 1m
     input_series:
       - series: 'process_resident_memory_bytes{job="rabbitmq", instance="localhost"}'
+        values: '0 200+0x28 100+0x30'
+      - series: 'namedprocess_namegroup_memory_bytes{groupname="rabbitmq", memtype="resident",instance="localhost"}'
         values: '0 200+0x28 100+0x30'
     alert_rule_test:
       - eval_time: 60m
         alertname: MemoryLeakFromExporter
         exp_alerts: []
+      - eval_time: 60m
+        alertname: MemoryLeak
+        exp_alerts: []
 
-  - name: when exporter memory increase slowly
+  - name: when memory increase slowly
     interval: 1m
     input_series:
       - series: 'process_resident_memory_bytes{job="rabbitmq", instance="localhost"}'
+        values: '0 100+1x59'
+      - series: 'namedprocess_namegroup_memory_bytes{groupname="rabbitmq", memtype="resident",instance="localhost"}'
         values: '0 100+1x59'
     alert_rule_test:
       - eval_time: 60m
@@ -117,6 +137,17 @@ tests:
               job: rabbitmq
             exp_annotations:
               summary: "Exporter rabbitmq has a potential memory leak"
+              description: "Instance **localhost**, Memory: 154.5"
+      - eval_time: 60m
+        alertname: MemoryLeak
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: localhost
+              groupname: rabbitmq
+              memtype: resident
+            exp_annotations:
+              summary: "Service rabbitmq has a potential memory leak"
               description: "Instance **localhost**, Memory: 154.5"
 
   - name: simultaneous calls


### PR DESCRIPTION
why:
- easier to use alerting from prometheus (because of promtool test tool)
  then the embedded alerting system from grafana
- This imply to use Alertmanager
