### PR TITLE
WP-1909-fix-nginx-exporter

### DIFF
--- a/monitor/prometheus-config-generator/prometheus.yaml.jinja2
+++ b/monitor/prometheus-config-generator/prometheus.yaml.jinja2
@@ -185,14 +185,6 @@ scrape_configs:
     static_configs:
       - targets: [{{ dump_stacks(443) }}]
 {% if edge_servers %}
-  - job_name: edge-nginx
-    scheme: http
-    tls_config:
-      insecure_skip_verify: true
-    metrics_path: /nginx/metrics
-    static_configs:
-      - targets: [{{ dump_edges(6387) }}]
-
   - job_name: edge-kamailio
     scheme: http
     tls_config:


### PR DESCRIPTION
why:
- they are not formatted for prometheus
- we already have traefik metrics
- The proper solution is overkill for now
