### PR TITLE
fix-healtcheck

### DIFF
--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - grafana-data:/var/lib/grafana:rw
     healthcheck:
       test: ["CMD", "wget", "-o", "/dev/null" , "-O", "/dev/null", "http://localhost:3000"]
+      start_period: 5s  # Let time for bootstrap (i.e. migration scripts)
       interval: 2s
       timeout: 1s
       retries: 5


### PR DESCRIPTION
why: on slow host, migration scripts can take many seconds
