### PR TITLE
increase-grafana-bootstrap

### DIFF
--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - grafana-data:/var/lib/grafana:rw
     healthcheck:
       test: ["CMD", "wget", "-o", "/dev/null" , "-O", "/dev/null", "http://localhost:3000"]
-      start_period: 5s  # Let time for bootstrap (i.e. migration scripts)
+      start_period: 30s  # Let time for bootstrap (i.e. migration scripts)
       interval: 2s
       timeout: 1s
       retries: 5


### PR DESCRIPTION
why: maybe it's our infra, but the bootstrap can be really long (up to
30sec)
However, if a success occurs during start_period, the healthcheck state
will be good before the 30sec (i.e. it's not a delay)
