### PR TITLE
monitor: allow tagging the instance only

### DIFF
--- a/monitor/terraform/monitor.tf
+++ b/monitor/terraform/monitor.tf
@@ -56,6 +56,8 @@ resource "aws_instance" "monitor" {
   user_data_replace_on_change = true
 
   vpc_security_group_ids = var.security_group_ids
+
+  tags = var.instance_tags
 }
 
 resource "aws_volume_attachment" "prometheus" {

--- a/monitor/terraform/variables.tf
+++ b/monitor/terraform/variables.tf
@@ -54,3 +54,9 @@ variable "cloud_config_files" {
   description = "cloud-config files to append to monitor instance cloud-config."
   default     = []
 }
+
+variable "instance_tags" {
+  type        = map(string)
+  description = "Tags to set on the monitor instance only, in addition to default_tags."
+  default     = {}
+}


### PR DESCRIPTION
Add an `instance_tags` variable so callers can set tags on the monitor instance without them being inherited by the attached EBS volume, which `default_tags` cannot express.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Terraform variable and tag wiring with no auth, data, or application logic changes.
> 
> **Overview**
> Adds an **`instance_tags`** input (map, default `{}`) and applies it to the **`aws_instance.monitor`** resource so callers can tag the EC2 instance without those tags flowing to the attached Prometheus EBS volume via **`default_tags`**.
> 
> Provider **`default_tags`** behavior is unchanged for other resources (e.g. the EBS volume).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fc62149c420744cf5d714308fb87572300805dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->